### PR TITLE
Basis tagging to try ordering by distance _and_ time

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,8 @@
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "test": "mocha",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "saveRun": "node ./test/saveUserWorkouts.js"
   },
   "engines": {
     "node": "16"

--- a/functions/parser/parser.js
+++ b/functions/parser/parser.js
@@ -214,7 +214,7 @@ function tagWorkoutTypes(laps) {
   const differenceThreshold = 1.2; // TODO Tune this
 
 
-  /* 
+  /*
   Try out the threshold system on both distances and times.
   We haven't assigned basises yet, so this will proxy for the true basis.
   By taking the basis that generates the fewest distinct workout types, we guard against pace variance, which manifests as
@@ -224,32 +224,32 @@ function tagWorkoutTypes(laps) {
   const workoutsSortedByDistance = [...workouts].sort((a, b) => a.distance < b.distance ? -1 : 1);
   const workoutsSortedByTime = [...workouts].sort((a, b) => a.moving_time < b.moving_time ? -1 : 1);
 
-  let workoutTypeCounter_d = 0;
-  let workoutTypeCounter_t = 0;
+  let workoutTypeCounterDistance = 0;
+  let workoutTypeCounterTime = 0;
 
   let prevWorkoutDistance = workoutsSortedByDistance[0].distance;
   for (const lap of workoutsSortedByDistance) {
     if ((lap.distance / prevWorkoutDistance) >= differenceThreshold) {
-      workoutTypeCounter_d += 1;
+      workoutTypeCounterDistance += 1;
     }
 
     prevWorkoutDistance = lap.distance;
-    lap.workoutType_d = workoutTypeCounter_d;
+    lap.workoutType_d = workoutTypeCounterDistance;
   }
 
   let prevWorkoutTime = workoutsSortedByTime[0].moving_time;
   for (const lap of workoutsSortedByTime) {
     if ((lap.moving_time / prevWorkoutTime) >= differenceThreshold) {
-      workoutTypeCounter_t += 1;
+      workoutTypeCounterTime += 1;
     }
 
-    prevWorkoutTime = lap.moving_time
-    lap.workoutType_t = workoutTypeCounter_t
+    prevWorkoutTime = lap.moving_time;
+    lap.workoutType_t = workoutTypeCounterTime;
   }
 
 
   // Take the system that generates the FEWEST distinct workout types
-  if (workoutTypeCounter_t > workoutTypeCounter_d) {
+  if (workoutTypeCounterTime > workoutTypeCounterDistance) {
     for (const lap of workouts) {
       lap.workoutType = lap.workoutType_d;
     }
@@ -265,7 +265,6 @@ function tagWorkoutTypes(laps) {
 }
 
 function tagWorkoutBasisAndValue(laps, parserConfig) {
-
   const maxWorkoutType = laps.map((lap) => lap.workoutType === undefined ? 0 : lap.workoutType).reduce((a, b) => Math.max(a, b), 0);
 
   for (let workoutType = 0; workoutType <= maxWorkoutType; workoutType++) {

--- a/functions/parser/parser.js
+++ b/functions/parser/parser.js
@@ -255,20 +255,23 @@ function tagWorkoutBasisAndValue(laps, parserConfig) {
       distanceStdDev = Math.sqrt(correspondingLaps.reduce((a, b) => a + Math.pow(b.closestDistanceDifference - distanceDifferenceAverage, 2), 0) / correspondingLaps.length).toFixed(4);
       timeStdDev = Math.sqrt(correspondingLaps.reduce((a, b) => a + Math.pow(b.closestTimeDifference - timeDifferenceAverage, 2), 0) / correspondingLaps.length).toFixed(4);
 
+      // console.log(`diff: ${distanceDifferenceAverage}, ${timeDifferenceAverage}`);
+      // console.log(`std : ${distanceStdDev}, ${timeStdDev}`);
+
       for (const lap of correspondingLaps) {
-        // Assign based on lowest std dev.
+        // Assign based on lowest average difference
         switch (parserConfig.dominantWorkoutType) {
           case "DISTANCE":
-            lap.workoutBasis = (distanceStdDev <= (biasFactor * timeStdDev) ? "DISTANCE" : "TIME");
+            lap.workoutBasis = (distanceDifferenceAverage <= (biasFactor * timeDifferenceAverage) ? "DISTANCE" : "TIME");
             break;
           case "TIME":
-            lap.workoutBasis = (timeStdDev <= (biasFactor * distanceStdDev) ? "TIME" : "DISTANCE");
+            lap.workoutBasis = (timeDifferenceAverage <= (biasFactor * distanceDifferenceAverage) ? "TIME" : "DISTANCE");
             break;
           case "BALANCED":
-            lap.workoutBasis = (distanceStdDev <= timeStdDev ? "DISTANCE" : "TIME");
+            lap.workoutBasis = (distanceDifferenceAverage <= timeDifferenceAverage ? "DISTANCE" : "TIME");
             break;
           default: // Same as balanced
-            lap.workoutBasis = (distanceStdDev <= timeStdDev ? "DISTANCE" : "TIME");
+            lap.workoutBasis = (distanceDifferenceAverage <= timeDifferenceAverage ? "DISTANCE" : "TIME");
             break;
         }
 

--- a/functions/test/saveUserWorkouts.js
+++ b/functions/test/saveUserWorkouts.js
@@ -1,7 +1,7 @@
 const {StravaInterface} = require("../strava_interface.js");
 const {DbInterface} = require("../db_interface.js");
 const userTestActivities = require("./user_test_runs.json");
-const userTestRunsPath = "./user_test_runs.json";
+const userTestRunsPath = "./test/user_test_runs.json";
 
 const fs = require("fs");
 const admin = require("firebase-admin");
@@ -84,9 +84,17 @@ function saveActivityForUser(userID, activityID) {
   });
 }
 
-// const testUserID = "";
-// const testActivityID = "";
-// saveActivityForUser(testUserID, testActivityID);
+
+const args = process.argv.slice(2); // skip `node` and the script name
+
+if (args[0] === "-h" || args[0] === "h") {
+  console.log("Usage: [activity ID] [userID (firebase)]");
+} else if (args.length === 2) {
+  const testActivityID = args[0];
+  const testUserID = args[1];
+
+  saveActivityForUser(testUserID, testActivityID);
+}
 
 module.exports = {
   cleanStravaActivity,

--- a/functions/test/test.js
+++ b/functions/test/test.js
@@ -1467,42 +1467,47 @@ describe("Parser", () => {
     });
   });
 
-  describe("TRICKY IRL WORKOUTS", () => {
-    it("Vicente 15/30 second sprints", () => {
-      resetConfigs();
+  describe("IRL WORKOUTS", () => {
+    describe("Basis tagging", () => {
+      it("Vicente 15/30 second sprints", () => {
+        resetConfigs();
 
-      const run = userTestRuns["pattern_reducer"]["vicente_1"];
-      const res = parseWorkout({
-        run: run,
-        config: {
-          parser: parserConfig,
-          format: formatConfig,
-        },
-        returnSets: true,
-        verbose: false,
+        const run = userTestRuns["pattern_reducer"]["vicente_1"];
+        const res = parseWorkout({
+          run: run,
+          config: {
+            parser: parserConfig,
+            format: formatConfig,
+          },
+          returnSets: true,
+          verbose: false,
+        });
+
+        const intervals = res.sets[1];
+
+        // Should be 4 x (15sec, 30sec)
+        assert.equal(intervals.pattern.length, 2);
+        assert.equal(intervals.count, 4);
       });
 
-      console.log(res.summary.title)
-      console.log(res.sets)
+      it("800m misparsed as 3min", () => {
+        resetConfigs();
+
+        const run = userTestRuns["incorrect_basis"]["3min_vs_800m"];
+        const res = parseWorkout({
+          run: run,
+          config: {
+            parser: parserConfig,
+            format: formatConfig,
+          },
+          returnSets: true,
+          verbose: false,
+        });
+
+        assert.ok(res.summary.title.includes("800m"));
+        assert.equal(res.sets[0].laps[0].workoutBasis, "DISTANCE");
+      });
     });
-
-    it("800m misparsed as 3min", () => {
-      resetConfigs();
-
-      const run = userTestRuns["incorrect_basis"]["3min_vs_800m"];
-      const res = parseWorkout({
-        run: run,
-        config: {
-          parser: parserConfig,
-          format: formatConfig,
-        },
-        returnSets: true,
-        verbose: false,
-      });
-
-      assert.equal(res.sets[0].laps[0].workoutBasis, 'DISTANCE');
-    })
-
   });
 
   describe("FALSE POSITIVES", () => {

--- a/functions/test/test.js
+++ b/functions/test/test.js
@@ -1468,6 +1468,40 @@ describe("Parser", () => {
   });
 
   describe("TRICKY IRL WORKOUTS", () => {
+    it("Vicente 15/30 second sprints", () => {
+      resetConfigs();
+
+      const run = userTestRuns["pattern_reducer"]["vicente_1"];
+      const res = parseWorkout({
+        run: run,
+        config: {
+          parser: parserConfig,
+          format: formatConfig,
+        },
+        returnSets: true,
+        verbose: false,
+      });
+
+      console.log(res.summary.title)
+      console.log(res.sets)
+    });
+
+    it("800m misparsed as 3min", () => {
+      resetConfigs();
+
+      const run = userTestRuns["incorrect_basis"]["3min_vs_800m"];
+      const res = parseWorkout({
+        run: run,
+        config: {
+          parser: parserConfig,
+          format: formatConfig,
+        },
+        returnSets: true,
+        verbose: false,
+      });
+
+      assert.equal(res.sets[0].laps[0].workoutBasis, 'DISTANCE');
+    })
 
   });
 

--- a/functions/test/user_test_runs.json
+++ b/functions/test/user_test_runs.json
@@ -922,7 +922,7 @@
             "average_heartrate": 177,
             "max_heartrate": 197
         },
-          "2": {
+        "2": {
             "laps": [
                 {
                     "elapsed_time": 1864,
@@ -1066,7 +1066,1046 @@
             "average_speed": 2.9853841595891764
         }
     },
-    "false_positive": {
-        
-    }
-}   
+    "false_positive": {},
+    "pattern_reducer": {
+        "vicente_1": {
+            "laps": [
+                {
+                    "id": 32252120209,
+                    "resource_state": 2,
+                    "name": "Lap 1",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 951,
+                    "moving_time": 533,
+                    "start_date": "2023-07-14T10:48:43Z",
+                    "start_date_local": "2023-07-14T06:48:43Z",
+                    "distance": 1784.57,
+                    "start_index": 0,
+                    "end_index": 116,
+                    "total_elevation_gain": 0,
+                    "average_speed": 3.35,
+                    "max_speed": 4.217,
+                    "average_cadence": 88,
+                    "device_watts": false,
+                    "average_heartrate": 142,
+                    "max_heartrate": 149,
+                    "lap_index": 1,
+                    "split": 1,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120215,
+                    "resource_state": 2,
+                    "name": "Lap 2",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 370,
+                    "moving_time": 370,
+                    "start_date": "2023-07-14T11:04:37Z",
+                    "start_date_local": "2023-07-14T07:04:37Z",
+                    "distance": 1608.52,
+                    "start_index": 117,
+                    "end_index": 228,
+                    "total_elevation_gain": 2.1,
+                    "average_speed": 4.35,
+                    "max_speed": 5.545,
+                    "average_cadence": 93.7,
+                    "device_watts": false,
+                    "average_heartrate": 161.9,
+                    "max_heartrate": 171,
+                    "lap_index": 2,
+                    "split": 2,
+                    "pace_zone": 3
+                },
+                {
+                    "id": 32252120222,
+                    "resource_state": 2,
+                    "name": "Lap 3",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 361,
+                    "moving_time": 361,
+                    "start_date": "2023-07-14T11:10:49Z",
+                    "start_date_local": "2023-07-14T07:10:49Z",
+                    "distance": 1608.95,
+                    "start_index": 229,
+                    "end_index": 351,
+                    "total_elevation_gain": 2.8,
+                    "average_speed": 4.46,
+                    "max_speed": 8.556,
+                    "average_cadence": 95.1,
+                    "device_watts": false,
+                    "average_heartrate": 175.5,
+                    "max_heartrate": 179,
+                    "lap_index": 3,
+                    "split": 3,
+                    "pace_zone": 3
+                },
+                {
+                    "id": 32252120230,
+                    "resource_state": 2,
+                    "name": "Lap 4",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 345,
+                    "moving_time": 345,
+                    "start_date": "2023-07-14T11:16:49Z",
+                    "start_date_local": "2023-07-14T07:16:49Z",
+                    "distance": 1611.45,
+                    "start_index": 352,
+                    "end_index": 472,
+                    "total_elevation_gain": 2.6,
+                    "average_speed": 4.67,
+                    "max_speed": 8.617,
+                    "average_cadence": 96.2,
+                    "device_watts": false,
+                    "average_heartrate": 181.7,
+                    "max_heartrate": 185,
+                    "lap_index": 4,
+                    "split": 4,
+                    "pace_zone": 3
+                },
+                {
+                    "id": 32252120236,
+                    "resource_state": 2,
+                    "name": "Lap 5",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 331,
+                    "moving_time": 331,
+                    "start_date": "2023-07-14T11:22:36Z",
+                    "start_date_local": "2023-07-14T07:22:36Z",
+                    "distance": 1610.17,
+                    "start_index": 473,
+                    "end_index": 610,
+                    "total_elevation_gain": 0,
+                    "average_speed": 4.86,
+                    "max_speed": 6.674,
+                    "average_cadence": 97.9,
+                    "device_watts": false,
+                    "average_heartrate": 189,
+                    "max_heartrate": 195,
+                    "lap_index": 5,
+                    "split": 5,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32252120240,
+                    "resource_state": 2,
+                    "name": "Lap 6",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 357,
+                    "moving_time": 99,
+                    "start_date": "2023-07-14T11:32:22Z",
+                    "start_date_local": "2023-07-14T07:32:22Z",
+                    "distance": 284.37,
+                    "start_index": 611,
+                    "end_index": 649,
+                    "total_elevation_gain": 3.6,
+                    "average_speed": 2.87,
+                    "max_speed": 4.582,
+                    "average_cadence": 86.4,
+                    "device_watts": false,
+                    "average_heartrate": 153.8,
+                    "max_heartrate": 169,
+                    "lap_index": 6,
+                    "split": 6,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120242,
+                    "resource_state": 2,
+                    "name": "Lap 7",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 15,
+                    "moving_time": 15,
+                    "start_date": "2023-07-14T11:34:04Z",
+                    "start_date_local": "2023-07-14T07:34:04Z",
+                    "distance": 99.63,
+                    "start_index": 650,
+                    "end_index": 656,
+                    "total_elevation_gain": 0,
+                    "average_speed": 6.64,
+                    "max_speed": 6.7,
+                    "average_cadence": 101.5,
+                    "device_watts": false,
+                    "average_heartrate": 172.8,
+                    "max_heartrate": 176,
+                    "lap_index": 7,
+                    "split": 7,
+                    "pace_zone": 6
+                },
+                {
+                    "id": 32252120247,
+                    "resource_state": 2,
+                    "name": "Lap 8",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 37,
+                    "moving_time": 37,
+                    "start_date": "2023-07-14T11:34:20Z",
+                    "start_date_local": "2023-07-14T07:34:20Z",
+                    "distance": 90.48,
+                    "start_index": 657,
+                    "end_index": 669,
+                    "total_elevation_gain": 0,
+                    "average_speed": 2.45,
+                    "max_speed": 5.624,
+                    "average_cadence": 85.5,
+                    "device_watts": false,
+                    "average_heartrate": 179.3,
+                    "max_heartrate": 181,
+                    "lap_index": 8,
+                    "split": 8,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120250,
+                    "resource_state": 2,
+                    "name": "Lap 9",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 30,
+                    "moving_time": 30,
+                    "start_date": "2023-07-14T11:34:57Z",
+                    "start_date_local": "2023-07-14T07:34:57Z",
+                    "distance": 147.84,
+                    "start_index": 670,
+                    "end_index": 683,
+                    "total_elevation_gain": 4.5,
+                    "average_speed": 4.93,
+                    "max_speed": 6.523,
+                    "average_cadence": 100.3,
+                    "device_watts": false,
+                    "average_heartrate": 179.2,
+                    "max_heartrate": 183,
+                    "lap_index": 9,
+                    "split": 9,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32252120252,
+                    "resource_state": 2,
+                    "name": "Lap 10",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 60,
+                    "moving_time": 60,
+                    "start_date": "2023-07-14T11:35:26Z",
+                    "start_date_local": "2023-07-14T07:35:26Z",
+                    "distance": 177.98,
+                    "start_index": 684,
+                    "end_index": 700,
+                    "total_elevation_gain": 0,
+                    "average_speed": 2.97,
+                    "max_speed": 6.064,
+                    "average_cadence": 85,
+                    "device_watts": false,
+                    "average_heartrate": 180.8,
+                    "max_heartrate": 186,
+                    "lap_index": 10,
+                    "split": 10,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120254,
+                    "resource_state": 2,
+                    "name": "Lap 11",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 15,
+                    "moving_time": 15,
+                    "start_date": "2023-07-14T11:36:25Z",
+                    "start_date_local": "2023-07-14T07:36:25Z",
+                    "distance": 70.65,
+                    "start_index": 701,
+                    "end_index": 707,
+                    "total_elevation_gain": 0,
+                    "average_speed": 4.71,
+                    "max_speed": 6.014,
+                    "average_cadence": 96.9,
+                    "device_watts": false,
+                    "average_heartrate": 173.7,
+                    "max_heartrate": 175,
+                    "lap_index": 11,
+                    "split": 11,
+                    "pace_zone": 3
+                },
+                {
+                    "id": 32252120255,
+                    "resource_state": 2,
+                    "name": "Lap 12",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 39,
+                    "moving_time": 39,
+                    "start_date": "2023-07-14T11:36:41Z",
+                    "start_date_local": "2023-07-14T07:36:41Z",
+                    "distance": 129.46,
+                    "start_index": 708,
+                    "end_index": 720,
+                    "total_elevation_gain": 0,
+                    "average_speed": 3.32,
+                    "max_speed": 5.7,
+                    "average_cadence": 85.5,
+                    "device_watts": false,
+                    "average_heartrate": 180.3,
+                    "max_heartrate": 182,
+                    "lap_index": 12,
+                    "split": 12,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120258,
+                    "resource_state": 2,
+                    "name": "Lap 13",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 30,
+                    "moving_time": 30,
+                    "start_date": "2023-07-14T11:37:22Z",
+                    "start_date_local": "2023-07-14T07:37:22Z",
+                    "distance": 152.39,
+                    "start_index": 721,
+                    "end_index": 732,
+                    "total_elevation_gain": 3.9,
+                    "average_speed": 5.08,
+                    "max_speed": 6.528,
+                    "average_cadence": 103.7,
+                    "device_watts": false,
+                    "average_heartrate": 179.1,
+                    "max_heartrate": 184,
+                    "lap_index": 13,
+                    "split": 13,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32252120260,
+                    "resource_state": 2,
+                    "name": "Lap 14",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 62,
+                    "moving_time": 62,
+                    "start_date": "2023-07-14T11:37:52Z",
+                    "start_date_local": "2023-07-14T07:37:52Z",
+                    "distance": 196.71,
+                    "start_index": 733,
+                    "end_index": 748,
+                    "total_elevation_gain": 0,
+                    "average_speed": 3.17,
+                    "max_speed": 5.794,
+                    "average_cadence": 85.1,
+                    "device_watts": false,
+                    "average_heartrate": 183.6,
+                    "max_heartrate": 187,
+                    "lap_index": 14,
+                    "split": 14,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120263,
+                    "resource_state": 2,
+                    "name": "Lap 15",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 15,
+                    "moving_time": 15,
+                    "start_date": "2023-07-14T11:38:55Z",
+                    "start_date_local": "2023-07-14T07:38:55Z",
+                    "distance": 73.24,
+                    "start_index": 749,
+                    "end_index": 755,
+                    "total_elevation_gain": 0,
+                    "average_speed": 4.88,
+                    "max_speed": 5.45,
+                    "average_cadence": 98.5,
+                    "device_watts": false,
+                    "average_heartrate": 179,
+                    "max_heartrate": 179,
+                    "lap_index": 15,
+                    "split": 15,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32252120268,
+                    "resource_state": 2,
+                    "name": "Lap 16",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 37,
+                    "moving_time": 37,
+                    "start_date": "2023-07-14T11:39:09Z",
+                    "start_date_local": "2023-07-14T07:39:09Z",
+                    "distance": 117.47,
+                    "start_index": 756,
+                    "end_index": 768,
+                    "total_elevation_gain": 0,
+                    "average_speed": 3.17,
+                    "max_speed": 5.152,
+                    "average_cadence": 84.7,
+                    "device_watts": false,
+                    "average_heartrate": 179.2,
+                    "max_heartrate": 181,
+                    "lap_index": 16,
+                    "split": 16,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120270,
+                    "resource_state": 2,
+                    "name": "Lap 17",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 30,
+                    "moving_time": 30,
+                    "start_date": "2023-07-14T11:39:47Z",
+                    "start_date_local": "2023-07-14T07:39:47Z",
+                    "distance": 156.05,
+                    "start_index": 769,
+                    "end_index": 782,
+                    "total_elevation_gain": 4.9,
+                    "average_speed": 5.2,
+                    "max_speed": 6.286,
+                    "average_cadence": 100.3,
+                    "device_watts": false,
+                    "average_heartrate": 179.7,
+                    "max_heartrate": 181,
+                    "lap_index": 17,
+                    "split": 17,
+                    "pace_zone": 5
+                },
+                {
+                    "id": 32252120272,
+                    "resource_state": 2,
+                    "name": "Lap 18",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 59,
+                    "moving_time": 59,
+                    "start_date": "2023-07-14T11:40:19Z",
+                    "start_date_local": "2023-07-14T07:40:19Z",
+                    "distance": 179.55,
+                    "start_index": 783,
+                    "end_index": 797,
+                    "total_elevation_gain": 0,
+                    "average_speed": 3.04,
+                    "max_speed": 4.156,
+                    "average_cadence": 84.5,
+                    "device_watts": false,
+                    "average_heartrate": 183,
+                    "max_heartrate": 187,
+                    "lap_index": 18,
+                    "split": 18,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120273,
+                    "resource_state": 2,
+                    "name": "Lap 19",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 16,
+                    "moving_time": 16,
+                    "start_date": "2023-07-14T11:41:17Z",
+                    "start_date_local": "2023-07-14T07:41:17Z",
+                    "distance": 90.69,
+                    "start_index": 798,
+                    "end_index": 806,
+                    "total_elevation_gain": 2,
+                    "average_speed": 5.67,
+                    "max_speed": 5.875,
+                    "average_cadence": 100.8,
+                    "device_watts": false,
+                    "average_heartrate": 177.7,
+                    "max_heartrate": 181,
+                    "lap_index": 19,
+                    "split": 19,
+                    "pace_zone": 6
+                },
+                {
+                    "id": 32252120276,
+                    "resource_state": 2,
+                    "name": "Lap 20",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 38,
+                    "moving_time": 38,
+                    "start_date": "2023-07-14T11:41:33Z",
+                    "start_date_local": "2023-07-14T07:41:33Z",
+                    "distance": 118.95,
+                    "start_index": 807,
+                    "end_index": 819,
+                    "total_elevation_gain": 0,
+                    "average_speed": 3.13,
+                    "max_speed": 5.379,
+                    "average_cadence": 86.4,
+                    "device_watts": false,
+                    "average_heartrate": 183.5,
+                    "max_heartrate": 186,
+                    "lap_index": 20,
+                    "split": 20,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32252120279,
+                    "resource_state": 2,
+                    "name": "Lap 21",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 30,
+                    "moving_time": 30,
+                    "start_date": "2023-07-14T11:42:12Z",
+                    "start_date_local": "2023-07-14T07:42:12Z",
+                    "distance": 160.37,
+                    "start_index": 820,
+                    "end_index": 834,
+                    "total_elevation_gain": 5.2,
+                    "average_speed": 5.35,
+                    "max_speed": 7.43,
+                    "average_cadence": 106.1,
+                    "device_watts": false,
+                    "average_heartrate": 182.4,
+                    "max_heartrate": 189,
+                    "lap_index": 21,
+                    "split": 21,
+                    "pace_zone": 5
+                },
+                {
+                    "id": 32252120284,
+                    "resource_state": 2,
+                    "name": "Lap 22",
+                    "activity": {
+                        "id": 9449152503,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 742,
+                    "moving_time": 694,
+                    "start_date": "2023-07-14T11:42:41Z",
+                    "start_date_local": "2023-07-14T07:42:41Z",
+                    "distance": 2291.11,
+                    "start_index": 835,
+                    "end_index": 991,
+                    "total_elevation_gain": 9,
+                    "average_speed": 3.3,
+                    "max_speed": 5.434,
+                    "average_cadence": 87.2,
+                    "device_watts": false,
+                    "average_heartrate": 164.8,
+                    "max_heartrate": 190,
+                    "lap_index": 22,
+                    "split": 22,
+                    "pace_zone": 1
+                }
+            ],
+            "name": "4mi progression+4x(15\", 30\") at Lemon Hill",
+            "description": "4mi — Avg: 5:52/mi\n6:10,01,5:45,31\nLast mile was tough but progression and hills were fun. Ethan keeps trying to break David Cai's app so had to back to dark ages here",
+            "athlete": {
+                "id": 24845649,
+                "resource_state": 1
+            },
+            "distance": 12758.8,
+            "moving_time": 3255,
+            "elapsed_time": 3980,
+            "total_elevation_gain": 67.7,
+            "workout_type": 0,
+            "id": 9449152503,
+            "start_date": "2023-07-14T10:48:43Z",
+            "average_speed": 3.92,
+            "max_speed": 8.617,
+            "has_heartrate": true,
+            "average_heartrate": 168.2,
+            "max_heartrate": 195
+        }
+    },
+    "incorrect_basis": {
+        "3min_vs_800m": {
+            "laps": [
+                {
+                    "id": 32197966260,
+                    "resource_state": 2,
+                    "name": "Lap 1",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 158,
+                    "moving_time": 158,
+                    "start_date": "2023-07-11T22:46:33Z",
+                    "start_date_local": "2023-07-11T18:46:33Z",
+                    "distance": 790,
+                    "start_index": 0,
+                    "end_index": 158,
+                    "total_elevation_gain": 0,
+                    "average_speed": 5,
+                    "max_speed": 7.592,
+                    "average_cadence": 97.9,
+                    "device_watts": false,
+                    "average_heartrate": 151,
+                    "max_heartrate": 173,
+                    "lap_index": 1,
+                    "split": 1,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32197966264,
+                    "resource_state": 2,
+                    "name": "Lap 2",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 79,
+                    "moving_time": 79,
+                    "start_date": "2023-07-11T22:49:12Z",
+                    "start_date_local": "2023-07-11T18:49:12Z",
+                    "distance": 60,
+                    "start_index": 159,
+                    "end_index": 238,
+                    "total_elevation_gain": 0,
+                    "average_speed": 0.76,
+                    "max_speed": 4.48,
+                    "average_cadence": 61.5,
+                    "device_watts": false,
+                    "average_heartrate": 173.8,
+                    "max_heartrate": 178,
+                    "lap_index": 2,
+                    "split": 2,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32197966269,
+                    "resource_state": 2,
+                    "name": "Lap 3",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 159,
+                    "moving_time": 159,
+                    "start_date": "2023-07-11T22:50:32Z",
+                    "start_date_local": "2023-07-11T18:50:32Z",
+                    "distance": 810,
+                    "start_index": 239,
+                    "end_index": 398,
+                    "total_elevation_gain": 0,
+                    "average_speed": 5.09,
+                    "max_speed": 6.422,
+                    "average_cadence": 97.5,
+                    "device_watts": false,
+                    "average_heartrate": 152,
+                    "max_heartrate": 163,
+                    "lap_index": 3,
+                    "split": 3,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32197966275,
+                    "resource_state": 2,
+                    "name": "Lap 4",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 75,
+                    "moving_time": 75,
+                    "start_date": "2023-07-11T22:53:12Z",
+                    "start_date_local": "2023-07-11T18:53:12Z",
+                    "distance": 60,
+                    "start_index": 399,
+                    "end_index": 473,
+                    "total_elevation_gain": 0,
+                    "average_speed": 0.8,
+                    "max_speed": 5.372,
+                    "average_cadence": 64,
+                    "device_watts": false,
+                    "average_heartrate": 164.2,
+                    "max_heartrate": 171,
+                    "lap_index": 4,
+                    "split": 4,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32197966278,
+                    "resource_state": 2,
+                    "name": "Lap 5",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 159,
+                    "moving_time": 159,
+                    "start_date": "2023-07-11T22:54:27Z",
+                    "start_date_local": "2023-07-11T18:54:27Z",
+                    "distance": 810,
+                    "start_index": 474,
+                    "end_index": 633,
+                    "total_elevation_gain": 0,
+                    "average_speed": 5.09,
+                    "max_speed": 6.862,
+                    "average_cadence": 97.7,
+                    "device_watts": false,
+                    "average_heartrate": 159.4,
+                    "max_heartrate": 168,
+                    "lap_index": 5,
+                    "split": 5,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32197966283,
+                    "resource_state": 2,
+                    "name": "Lap 6",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 73,
+                    "moving_time": 73,
+                    "start_date": "2023-07-11T22:57:07Z",
+                    "start_date_local": "2023-07-11T18:57:07Z",
+                    "distance": 60,
+                    "start_index": 634,
+                    "end_index": 707,
+                    "total_elevation_gain": 0,
+                    "average_speed": 0.82,
+                    "max_speed": 6.274,
+                    "average_cadence": 75.1,
+                    "device_watts": false,
+                    "average_heartrate": 167.3,
+                    "max_heartrate": 184,
+                    "lap_index": 6,
+                    "split": 6,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32197966288,
+                    "resource_state": 2,
+                    "name": "Lap 7",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 160,
+                    "moving_time": 160,
+                    "start_date": "2023-07-11T22:58:21Z",
+                    "start_date_local": "2023-07-11T18:58:21Z",
+                    "distance": 800,
+                    "start_index": 708,
+                    "end_index": 867,
+                    "total_elevation_gain": 0,
+                    "average_speed": 5,
+                    "max_speed": 7.144,
+                    "average_cadence": 98.2,
+                    "device_watts": false,
+                    "average_heartrate": 167.6,
+                    "max_heartrate": 176,
+                    "lap_index": 7,
+                    "split": 7,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32197966294,
+                    "resource_state": 2,
+                    "name": "Lap 8",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 76,
+                    "moving_time": 76,
+                    "start_date": "2023-07-11T23:01:01Z",
+                    "start_date_local": "2023-07-11T19:01:01Z",
+                    "distance": 70,
+                    "start_index": 868,
+                    "end_index": 944,
+                    "total_elevation_gain": 0,
+                    "average_speed": 0.92,
+                    "max_speed": 4.62,
+                    "average_cadence": 62.9,
+                    "device_watts": false,
+                    "average_heartrate": 167.9,
+                    "max_heartrate": 181,
+                    "lap_index": 8,
+                    "split": 8,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32197966300,
+                    "resource_state": 2,
+                    "name": "Lap 9",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 159,
+                    "moving_time": 159,
+                    "start_date": "2023-07-11T23:02:18Z",
+                    "start_date_local": "2023-07-11T19:02:18Z",
+                    "distance": 800,
+                    "start_index": 945,
+                    "end_index": 1103,
+                    "total_elevation_gain": 0,
+                    "average_speed": 5.03,
+                    "max_speed": 6.56,
+                    "average_cadence": 98.1,
+                    "device_watts": false,
+                    "average_heartrate": 168.4,
+                    "max_heartrate": 179,
+                    "lap_index": 9,
+                    "split": 9,
+                    "pace_zone": 4
+                },
+                {
+                    "id": 32197966307,
+                    "resource_state": 2,
+                    "name": "Lap 10",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 75,
+                    "moving_time": 75,
+                    "start_date": "2023-07-11T23:04:57Z",
+                    "start_date_local": "2023-07-11T19:04:57Z",
+                    "distance": 70,
+                    "start_index": 1104,
+                    "end_index": 1179,
+                    "total_elevation_gain": 0,
+                    "average_speed": 0.93,
+                    "max_speed": 4.62,
+                    "average_cadence": 63.2,
+                    "device_watts": false,
+                    "average_heartrate": 175.9,
+                    "max_heartrate": 188,
+                    "lap_index": 10,
+                    "split": 10,
+                    "pace_zone": 1
+                },
+                {
+                    "id": 32197966313,
+                    "resource_state": 2,
+                    "name": "Lap 11",
+                    "activity": {
+                        "id": 9433915968,
+                        "resource_state": 1
+                    },
+                    "athlete": {
+                        "id": 24845649,
+                        "resource_state": 1
+                    },
+                    "elapsed_time": 158,
+                    "moving_time": 158,
+                    "start_date": "2023-07-11T23:06:13Z",
+                    "start_date_local": "2023-07-11T19:06:13Z",
+                    "distance": 810,
+                    "start_index": 1180,
+                    "end_index": 1337,
+                    "total_elevation_gain": 0,
+                    "average_speed": 5.13,
+                    "max_speed": 6.542,
+                    "average_cadence": 99,
+                    "device_watts": false,
+                    "average_heartrate": 180.2,
+                    "max_heartrate": 193,
+                    "lap_index": 11,
+                    "split": 11,
+                    "pace_zone": 5
+                }
+            ],
+            "name": "6x800",
+            "description": "⏱️ 6 x 800 — Avg: 2:39. 75 seconds recovery \nFirst workout under coach Ethan Hermann. Felt heat, poor fitness, and lingering hamstring issues but good to be back working out on track\n\nWorkout summary generated by workoutsplitz.com",
+            "athlete": {
+                "id": 24845649,
+                "resource_state": 1
+            },
+            "distance": 5136.3,
+            "moving_time": 1111,
+            "elapsed_time": 1337,
+            "total_elevation_gain": 0,
+            "workout_type": 0,
+            "id": 9433915968,
+            "start_date": "2023-07-11T22:46:33Z",
+            "average_speed": 4.623,
+            "max_speed": 7.592,
+            "has_heartrate": true,
+            "average_heartrate": 163.8,
+            "max_heartrate": 193
+        }
+    },
+    "uncategorized": [
+
+    ]
+}


### PR DESCRIPTION
Previously basis tagging sorted workout laps by distance, then iterated through the laps, looking for jumps above a threshold.

Now, it does the same thing but sorted by **time**, then takes the result (distance vs. time sorted) that produces the _fewest_ distinct workout types.

The idea is that since we don't actually know the basis at this point, we don't know which dimension we expect to remain consistent across reps, so we try both and our heuristic is to bias towards simplicity (the failure case is tagging a set of reps of the same workout as two different workout types).

Also made using saving user workouts slightly easier to use.