### PR TITLE
Strava api lag workarounds

### DIFF
--- a/functions/db_interface.js
+++ b/functions/db_interface.js
@@ -256,18 +256,18 @@ class DbInterface {
   getIsWorkoutWritten(activityID, callback) {
     const todayDatestamp = this.generateDatestamp();
     const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1)
+    yesterday.setDate(yesterday.getDate() - 1);
     const yesterdayDatestamp = this.generateDatestamp(yesterday);
 
     const todayRef = this.db.ref(`analytics/parsedWorkouts/${todayDatestamp}`);
     const yesterdayRef = this.db.ref(`analytics/parsedWorkouts/${yesterdayDatestamp}`);
 
-    todayRef.orderByChild(`activityID`).equalTo(activityID).on('value', (snapshot) => {
+    todayRef.orderByChild(`activityID`).equalTo(activityID).on("value", (snapshot) => {
       const writtenWorkoutFoundToday = snapshot.exists();
       if (writtenWorkoutFoundToday) { // If false, check yesterday
         callback(writtenWorkoutFoundToday);
       } else {
-        yesterdayRef.orderByChild(`activityID`).equalTo(activityID).on('value', (snapshot) => {
+        yesterdayRef.orderByChild(`activityID`).equalTo(activityID).on("value", (snapshot) => {
           const writtenWorkoutFoundYesterday = snapshot.exists();
           callback(writtenWorkoutFoundYesterday); // Send regardless of result since we're only looking at today and yesterday
         });

--- a/functions/db_interface.js
+++ b/functions/db_interface.js
@@ -156,7 +156,7 @@ class DbInterface {
     return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
   }
 
-  storeWorkoutForAnalytics(activityID, userID, parsedOutput) {
+  storeWrittenWorkout(activityID, userID, parsedOutput) {
     const datestamp = this.generateDatestamp();
 
     this.db.ref(`analytics/parsedWorkouts/${datestamp}`).push({
@@ -171,7 +171,7 @@ class DbInterface {
 
   fillWorkouts() {
     for (let i = 0; i < 10; i++) {
-      this.storeWorkoutForAnalytics("123", "456", {title: "4x400m", description: "4 x 400m — Avg: 59\n59,58,57,56"});
+      this.storeWrittenWorkout("123", "456", {title: "4x400m", description: "4 x 400m — Avg: 59\n59,58,57,56"});
     }
   }
 
@@ -251,6 +251,28 @@ class DbInterface {
     //       ]
     //     }
     //   ]
+  }
+
+  getIsWorkoutWritten(activityID, callback) {
+    const todayDatestamp = this.generateDatestamp();
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1)
+    const yesterdayDatestamp = this.generateDatestamp(yesterday);
+
+    const todayRef = this.db.ref(`analytics/parsedWorkouts/${todayDatestamp}`);
+    const yesterdayRef = this.db.ref(`analytics/parsedWorkouts/${yesterdayDatestamp}`);
+
+    todayRef.orderByChild(`activityID`).equalTo(activityID).on('value', (snapshot) => {
+      const writtenWorkoutFoundToday = snapshot.exists();
+      if (writtenWorkoutFoundToday) { // If false, check yesterday
+        callback(writtenWorkoutFoundToday);
+      } else {
+        yesterdayRef.orderByChild(`activityID`).equalTo(activityID).on('value', (snapshot) => {
+          const writtenWorkoutFoundYesterday = snapshot.exists();
+          callback(writtenWorkoutFoundYesterday); // Send regardless of result since we're only looking at today and yesterday
+        });
+      }
+    });
   }
 }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -146,6 +146,78 @@ app.get("/strava_webhook", (req, res) => {
   StravaInterface.webhookCreationResponse(req, res);
 });
 
+function webhookIsAccountDeauth(req) {
+  if (req.body.aspect_type === "update") {
+    if ("updates" in req.body) { // being defensive here
+      if ("authorized" in req.body.updates) {
+        if (req.body.updates.authorized === "false") {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+function webhookIsDefaultTitleUpdate(req) {
+  const defaultRunTitles = ["Morning run", "Lunch run", "Afternoon run", "Evening run", "Night run"];
+
+  if (req.body.aspect_type === "update") {
+    if ("updates" in req.body) { // being defensive here
+      if (req.body.updates === "title") {
+        const newTitle = req.body.updates.title;
+        return defaultRunTitles.includes(newTitle);
+      }
+    }
+  }
+
+  return false;
+}
+
+function processActivity(activityID, userStravaID, isTest) {
+  dbInterface.getUserIDForStravaID(userStravaID, (userID) => {
+    dbInterface.getStravaTokenForID(userID, (stravaToken) => {
+      StravaInterface.getActivity(activityID, stravaToken, (activity) => {
+        if (activity.type === "Run") {
+          if (!isTest) {
+            logAnalytics(ANALYTICS_EVENTS.ACTIVITY_IS_ELIGIBLE, db);
+          }
+
+          dbInterface.getPreferencesForUser(userID, (config) => {
+            const output = parseWorkout({
+              run: activity,
+              config: config,
+              verbose: false,
+            });
+            if (output.isWorkout) {
+              console.log(`ACTIVITY ${activityID} is a workout. Title: [${output.summary.title}] Description: [${output.summary.description.replace(new RegExp("\n", "g"), " || ")}]`);
+              if (!isTest) {
+                logAnalytics(ANALYTICS_EVENTS.WORKOUT_DETECTED, db);
+              }
+              setTimeout(() => {
+                if (isTest) {
+                  output.summary.title += ` ${new Date()}`;
+                  output.summary.description += `\n${new Date()}`;
+                }
+                StravaInterface.writeSummaryToStrava(activityID, output.summary, stravaToken);
+                if (!isTest) {
+                  logAnalytics(ANALYTICS_EVENTS.WORKOUT_WRITTEN, db);
+                  dbInterface.storeWrittenWorkout(activityID, userID, output.summary);
+                }
+              }, 0); // Keep the timeout framework but no timeout for now
+            } else {
+              console.log(`ACTIVITY ${activityID} is NOT a workout, no action taken.`);
+            }
+          });
+        } else {
+          console.log(`ACTIVITY ${activityID} is NOT a run, no action taken.`);
+        }
+      });
+    }, isTest); // Force a refresh for code-exercise purposes if in test mode
+  });
+}
+
 // Store all logic in a function for easy access by tests
 function handleIncomingWebhook(req, res, isTest=false) {
   if (!isTest) {
@@ -153,18 +225,10 @@ function handleIncomingWebhook(req, res, isTest=false) {
   }
 
   // Decide if we want to process the event
-  const isActivityUpdate = req.body.object_type === "activity";
-  const isRelevantUpdateType = req.body.aspect_type === "create";// || (req.body.aspect_type === "update" && (req.body.updates === "title" || req.body.updates === "type"));
-  let isAccountDeauthorization = false;
-  if (req.body.aspect_type === "update") {
-    if ("updates" in req.body) { // being defensive here
-      if ("authorized" in req.body.updates) {
-        if (req.body.updates.authorized === "false") {
-          isAccountDeauthorization = true;
-        }
-      }
-    }
-  }
+  const isActivity = req.body.object_type === "activity";
+  const isCreate = req.body.aspect_type === "create"; // || (req.body.aspect_type === "update" && (req.body.updates === "title" || req.body.updates === "type"));
+  const isAccountDeauthorization = webhookIsAccountDeauth(req);
+  const isStravaDefaultTitleUpdate = webhookIsDefaultTitleUpdate(req);
 
   const activityID = req.body.object_id;
   const userStravaID = req.body.owner_id;
@@ -173,59 +237,34 @@ function handleIncomingWebhook(req, res, isTest=false) {
     StravaInterface.acknowledgeWebhook(res);
   }
 
-  if (isActivityUpdate && isRelevantUpdateType) {
-    dbInterface.getUserIDForStravaID(userStravaID, (userID) => {
-      dbInterface.getStravaTokenForID(userID, (stravaToken) => {
-        StravaInterface.getActivity(activityID, stravaToken, (activity) => {
-          if (activity.type === "Run") {
-            if (!isTest) {
-              logAnalytics(ANALYTICS_EVENTS.ACTIVITY_IS_ELIGIBLE, db);
-            }
-
-            dbInterface.getPreferencesForUser(userID, (config) => {
-              const output = parseWorkout({
-                run: activity,
-                config: config,
-                verbose: false,
-              });
-              if (output.isWorkout) {
-                console.log(`ACTIVITY ${activityID} is a workout. Title: [${output.summary.title}] Description: [${output.summary.description.replace(new RegExp("\n", "g"), " || ")}]`);
-                if (!isTest) {
-                  logAnalytics(ANALYTICS_EVENTS.WORKOUT_DETECTED, db);
-                }
-                setTimeout(() => {
-                  if (isTest) {
-                    output.summary.title += ` ${new Date()}`;
-                    output.summary.description += `\n${new Date()}`;
-                  }
-                  StravaInterface.writeSummaryToStrava(activityID, output.summary, stravaToken);
-                  if (!isTest) {
-                    logAnalytics(ANALYTICS_EVENTS.WORKOUT_WRITTEN, db);
-                    dbInterface.storeWorkoutForAnalytics(activityID, userID, output.summary);
-                  }
-                }, 0); // Keep the timeout framework but no timeout for now
-              } else {
-                console.log(`ACTIVITY ${activityID} is NOT a workout, no action taken.`);
-              }
-            });
-          } else {
-            console.log(`ACTIVITY ${activityID} is NOT a run, no action taken.`);
-          }
-        });
-      }, isTest); // Force a refresh for code-exercise purposes if in test mode
+  if (isActivity && isCreate) {
+    dbInterface.getIsWorkoutWritten(activityID, (isWritten) => {
+      /*
+      Sometimes we get a second ping if the function doesn't start up soon enough to ack the webhook in time. 
+      Even so, we still do the full parse+write (if it's a workout) in response to the first webhook, so the second write is unnecessary.
+      The second write can be harmful if the user updates the activity between the two webhooks because the second write would overwrite the user's changes.
+      */
+      if (!isWritten) {
+        processActivity(activityID, userStravaID, isTest);
+      }
     });
+  } else if (isActivity && isStravaDefaultTitleUpdate) {
+    dbInterface.getIsWorkoutWritten(activityID, (isWritten) => {
+      // If we've already written the workout, and we subsequently receive a default title update, it means we were overwritten and we need to re-write
+      if (isWritten) {
+        processActivity(activityID, userStravaID, isTest);
+      }
+    })
   } else if (isAccountDeauthorization) {
     dbInterface.getUserIDForStravaID(req.body.owner_id, (userID) => {
       dbInterface.deleteUser(userID);
       logAnalytics(ANALYTICS_EVENTS.USER_STRAVA_DEACTIVATION, db);
     });
+  } else if (req.body.aspect_type === "update") {
+    console.log(`Received update for ACTIVITY ${activityID}, no action taken.`);
   } else {
-    if (req.body.aspect_type === "update") {
-      console.log(`Received update for ACTIVITY ${activityID}, no action taken.`);
-    } else {
-      console.log(`Webhook for ACTIVITY ${activityID} is not eligible.`);
-    }
-  }
+    console.log(`Webhook for ACTIVITY ${activityID} is not eligible.`);
+  };
 }
 
 app.post("/strava_webhook", (req, res) => {

--- a/functions/parser/defaultConfigs.js
+++ b/functions/parser/defaultConfigs.js
@@ -18,8 +18,11 @@ const defaultAccountSettingsConfig = {
   "emailOptIn": true, // true, false
 };
 
+const knownStravaDefaultRunNames = ["Morning run", "Lunch run", "Afternoon run", "Evening run", "Night run"];
+
 module.exports = {
   defaultFormatConfig,
   defaultParserConfig,
   defaultAccountSettingsConfig,
+  knownStravaDefaultRunNames,
 };

--- a/functions/strava_interface.js
+++ b/functions/strava_interface.js
@@ -69,8 +69,6 @@ class StravaInterface {
 
   static writeSummaryToStrava(activityID, summary, accessToken) {
     const stravaConfigDetails = this.stravaConfigDetails();
-    // console.log(`Writing workout:\n\tActivity: ${activityID}\n\tTitle:${summary.title}\n\tDescription:${summary.description.replace("\n", "")}`);
-
     const config = {headers: {Accept: "application/json", Authorization: `Bearer ${accessToken}`}};
     const newTitleAndDescription = {
       "name": summary.title,

--- a/functions/test/test.js
+++ b/functions/test/test.js
@@ -1514,3 +1514,13 @@ describe("Parser", () => {
 
   });
 });
+
+describe("Strava interface", () => {
+  describe("Detecting variations of defualt run titles", () => {
+
+  });
+
+  describe("Ensuring normal titles aren't interpretted as default title", () => {
+
+  });
+})

--- a/functions/test/test.js
+++ b/functions/test/test.js
@@ -1514,13 +1514,3 @@ describe("Parser", () => {
 
   });
 });
-
-describe("Strava interface", () => {
-  describe("Detecting variations of defualt run titles", () => {
-
-  });
-
-  describe("Ensuring normal titles aren't interpretted as default title", () => {
-
-  });
-})


### PR DESCRIPTION
Using the existing `analytics/parsedWorkouts` storage, check if:
- An incoming `create` was already written, ignore if so
  - --> This prevents unintentional overwriting of a person's own edits to the title/summary
- An incoming update sets an already-written workout to a default run title
  - --> This indicates a race condition where the run was saved (and thus, default title was set) _after_ Splitz wrote its summary, so we need to rewrite the summary